### PR TITLE
Fix for: WARNING: Please set conf.dot15d4_protocol to select a 802.15…

### DIFF
--- a/zigbee-viewer.py
+++ b/zigbee-viewer.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import scapy
 from scapy.all import rdpcap, ZigbeeNWK, ZigbeeSecurityHeader
 from Cryptodome.Cipher import AES
 from binascii import unhexlify
@@ -108,6 +109,7 @@ def usage(cmd):
 
 
 def main(argv):
+    scapy.config.Conf.dot15d4_protocol = "zigbee"
     try:
         pkts = rdpcap(argv[1])
     except IOError:


### PR DESCRIPTION
Seems like newer versions of scapy requires that one selects the protocol decode on the 802.15.4 
This change configures selects zigbee as the protocol